### PR TITLE
use curl by default in recaptcha check

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -323,7 +323,10 @@ class Data extends CoreHelper
             return $result;
         }
         try {
-            $recaptchaClass = new ReCaptcha($end === 'visible' ? $this->getVisibleSecretKey() : $this->getInvisibleSecretKey());
+            $recaptchaClass = new ReCaptcha(
+                $end === 'visible' ? $this->getVisibleSecretKey() : $this->getInvisibleSecretKey(),
+                function_exists('curl_init') ? new \ReCaptcha\RequestMethod\CurlPost() : null
+            );
             $resp = $recaptchaClass->verify($recaptcha, $this->_request->getClientIp());
             if ($resp && $resp->isSuccess()) {
                 $result['success'] = true;


### PR DESCRIPTION
Sometimes there is error on form validation
`
Warning: file_get_contents(): SSL operation failed with code 1. OpenSSL Error messages: error:0A000126:SSL routines::unexpected eof while reading in /*/vendor/google/recaptcha/src/ReCaptcha/RequestMethod/Post.php on line 80`

Try to use CurlRequest firstly if curl enabled