### PR TITLE
Fix issue with M2.4.4 and Php8.1

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -261,7 +261,7 @@ class Data extends CoreHelper
                 $data[] = $value;
             }
         }
-        $custom = explode("\n", str_replace("\r", '', $this->getConfigFrontend('custom/paths', $storeId)));
+        $custom = explode("\n", str_replace("\r", '', $this->getConfigFrontend('custom/paths', $storeId) ?? ''));
         if (!$custom) {
             return $data;
         }
@@ -277,7 +277,7 @@ class Data extends CoreHelper
     public function getCssSelectors($storeId = null)
     {
         $data = $this->getConfigFrontend('custom/css', $storeId);
-        $forms = explode("\n", str_replace("\r", '', $data));
+        $forms = explode("\n", str_replace("\r", '', $data ?? ''));
         foreach ($forms as $key => $value) {
             $forms[$key] = trim($value, ' ');
         }


### PR DESCRIPTION
After the upgrade with M2.4.4-p2 and Php8.1, we detect this issues: 

[2023-01-10T10:09:50.084114+00:00] main.ERROR: Deprecated Functionality: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /vendor/mageplaza/module-google-recaptcha/Helper/Data.php on line 264 [] [] [2023-01-10T10:09:50.084364+00:00] main.CRITICAL: Exception: Deprecated Functionality: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /vendor/mageplaza/module-google-recaptcha/Helper/Data.php on line 264

I also fixed: https://github.com/mageplaza/magento-2-google-recaptcha/issues/73

Regards, 
Francisco