### PR TITLE
PHP 8.1 Deprecated Functionality: str_replace() bugfix

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -261,7 +261,7 @@ class Data extends CoreHelper
                 $data[] = $value;
             }
         }
-        $custom = explode("\n", str_replace("\r", '', $this->getConfigFrontend('custom/paths', $storeId)));
+        $custom = explode("\n", str_replace("\r", '', $this->getConfigFrontend('custom/paths', $storeId) ?? ''));
         if (!$custom) {
             return $data;
         }
@@ -277,7 +277,7 @@ class Data extends CoreHelper
     public function getCssSelectors($storeId = null)
     {
         $data = $this->getConfigFrontend('custom/css', $storeId);
-        $forms = explode("\n", str_replace("\r", '', $data));
+        $forms = explode("\n", str_replace("\r", '', $data ?? ''));
         foreach ($forms as $key => $value) {
             $forms[$key] = trim($value, ' ');
         }


### PR DESCRIPTION
Fix to "main.ERROR: Deprecated Functionality: str_replace(): Passing null to parameter https://github.com/mageplaza/magento-2-google-recaptcha/issues/3 ($subject) of type array|string is deprecated in /vendor/mageplaza/module-google-recaptcha/Helper/Data.php on line 264"